### PR TITLE
Fix search icon frozen in high

### DIFF
--- a/src/Viewer/components/Monaco/utils.ts
+++ b/src/Viewer/components/Monaco/utils.ts
@@ -48,7 +48,6 @@ const initMonacoEditor = (
     const editor = monaco.editor.create(
         editorContainer,
         {
-            // FIXME: add custom observer debounce automatic layout
             automaticLayout: false,
             language: LOG_LANGUAGE_NAME,
             maxTokenizationLineLength: 30_000,
@@ -60,8 +59,8 @@ const initMonacoEditor = (
         }
     );
 
-    let resizeTimeout: NodeJS.Timeout;
-    const resizeObserver = new ResizeObserver((entries) => {
+    let resizeTimeout: NodeJS.Timeout | null = null;
+    const resizeObserver = new ResizeObserver(() => {
         if (null !== resizeTimeout) {
             console.log("canceled");
             clearTimeout(resizeTimeout);

--- a/src/Viewer/components/Monaco/utils.ts
+++ b/src/Viewer/components/Monaco/utils.ts
@@ -59,10 +59,9 @@ const initMonacoEditor = (
         }
     );
 
-    let resizeTimeout: NodeJS.Timeout | null = null;
+    let resizeTimeout: ReturnType<typeof setTimeout> | null = null;
     const resizeObserver = new ResizeObserver(() => {
         if (null !== resizeTimeout) {
-            console.log("canceled");
             clearTimeout(resizeTimeout);
         }
         resizeTimeout = setTimeout(() => {

--- a/src/Viewer/components/Monaco/utils.ts
+++ b/src/Viewer/components/Monaco/utils.ts
@@ -49,7 +49,7 @@ const initMonacoEditor = (
         editorContainer,
         {
             // FIXME: add custom observer debounce automatic layout
-            automaticLayout: true,
+            automaticLayout: false,
             language: LOG_LANGUAGE_NAME,
             maxTokenizationLineLength: 30_000,
             mouseWheelZoom: true,
@@ -59,6 +59,19 @@ const initMonacoEditor = (
             wordWrap: "on",
         }
     );
+
+    let resizeTimeout: NodeJS.Timeout;
+    const resizeObserver = new ResizeObserver((entries) => {
+        if (null !== resizeTimeout) {
+            console.log("canceled");
+            clearTimeout(resizeTimeout);
+        }
+        resizeTimeout = setTimeout(() => {
+            editor.layout();
+        }, 250);
+    });
+
+    resizeObserver.observe(editorContainer);
 
     setupShortcutActions(editor, changeAppState);
     setupCursorPosChangeAction(editor, changeAppState);

--- a/src/Viewer/components/Monaco/utils.ts
+++ b/src/Viewer/components/Monaco/utils.ts
@@ -12,6 +12,8 @@ import {setupShortcutActions} from "./shortcuts";
 import {setupThemes} from "./themes";
 
 
+const MONACO_RESIZE_DEBOUNCE_TIMEOUT = 250;
+
 /**
  * Centers the line in the editor and change the cursor position.
  *
@@ -66,7 +68,7 @@ const initMonacoEditor = (
         }
         resizeTimeout = setTimeout(() => {
             editor.layout();
-        }, 250);
+        }, MONACO_RESIZE_DEBOUNCE_TIMEOUT);
     });
 
     resizeObserver.observe(editorContainer);


### PR DESCRIPTION
# Description
The entire browser freezes when toggling search panel on and off. This is due to using Monaco Editor's automatic layout option when the log events per page is high. Instead, a timeout function can be used to disable frequent search panel toggling.

# Validation performed
Open log viewer, set log events per message to `10000000`.
Toggle search panel on and off within 250ms, observe that the page doesn't freeze.

